### PR TITLE
fix false negative when drive hex address is non-numeric 

### DIFF
--- a/test/unvme-setup
+++ b/test/unvme-setup
@@ -133,7 +133,7 @@ else
     vfio_check
     for i in $*; do
         case $i in
-        [0-9][0-9]:*)
+        [0-9a-f][0-9a-f]:*)
             if [ -z "$(lspci -n | grep $i\ 0108\:)" ]; then
                 echo -e "No NVMe device at PCI $i"
                 myusage


### PR DESCRIPTION
for example
 3e:00.0 Non-Volatile memory controller: Samsung Electronics Co Ltd NVMe SSD Controller (rev 01)