### PR TITLE
Default queue size

### DIFF
--- a/src/unvme_core.c
+++ b/src/unvme_core.c
@@ -515,7 +515,7 @@ unvme_ns_t* unvme_do_open(int pci, int nsid, int qcount, int qsize)
             FATAL("nvme_acmd_get_features number of queues failed");
         int maxqcount = (nq.nsq < nq.ncq ? nq.nsq : nq.ncq) + 1;
         if (qcount <= 0) qcount = maxqcount;
-        if (qsize <= 1) qsize = UNVME_QSIZE;
+        if (qsize <= 1) qsize = dev->nvmedev.maxqsize;
         ns->maxqcount = maxqcount;
         ns->qcount = qcount;
         ns->qsize = qsize;


### PR DESCRIPTION
Default queue size changed from UNVME_QSIZE(256) to MQES in CAP
(Controller register)

unvme_open() uses UNVME_QSIZE(256) as a default io queue size when 0 is given as an io queue size.

If MQES is less then 255, create io queue command with UNVME_QSIZE will fails.

The default queue size should be taken from MQES value in CAP instead of hard-coded value 256.